### PR TITLE
Compile majority of Cisco IOS XRd models

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -7,8 +7,8 @@
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/05f32119fed94accf830bcc5e77457701016feeb.zip",
-            "hash": "1220f7bec2f5fc698553550de44e5e48a52426920ce6b6659595b97b89921466d884"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/9754c380a81c50d8971f297da1dcd279b6e3751a.zip",
+            "hash": "122044ce085d33225325feb1ceadf73e4363f3f13a732236a2dcfdbcc28a0718478a"
         }
     },
     "zig_dependencies": {}

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -173,7 +173,11 @@ actor CmdGetConfig(env, args, log_handler):
         """Collect downloaded schemas into the list"""
         if schema_data is not None:
             schema_identifier = schema.identifier
-            if schema_identifier is not None and schema_identifier.startswith("junos-rpc"):
+            # Skip models:
+            # - junos-rpc: all RPC modules use an undefined grouping?!
+            # - openconfig: on Cisco IOS XRd openconfig-mpls.yang doesn't compile because submodule overrides prefix of parent import
+            if schema_identifier is not None and (schema_identifier.startswith("junos-rpc") or "openconfig" in schema_identifier):
+                print("Skipping {schema_identifier}", err=True)
                 return
             schemas.append(schema_data)
 

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -10,6 +10,7 @@ import argparse
 import file
 import logging
 import netconf
+import time
 import xml
 
 
@@ -197,11 +198,14 @@ actor CmdGetConfig(env, args, log_handler):
 
         print("Retrieved {len(schemas)} schemas")
 
+        t0 = time.Stopwatch()
         root = yang.compile(schemas)
-        print("Compiled schema")
+        print("Compiled schemas in {t0.elapsed().to_float()}s")
+        t0.reset()
         c = config_xml
         if c is not None:
             gdata = yang.gen3.from_xml(root, c, loose=True)
+            print("Parsed config to gdata in {t0.elapsed().to_float()}s")
 
             if format == "json":
                 _output_config(gdata.to_json())


### PR DESCRIPTION
With the updated acton-yang library, we can compile all Cisco IOS XRd YANG, except openconfig, which we're not using anyway.