### PR TITLE
Add set-based schema filtering for YANG modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
         run: ./ncurl --verbose list-schemas
       - name: "Test ncurl get-config with JSON format"
         run: ./ncurl get-config --format json
+      - name: "Test ncurl get-config with explicit module set"
+        run: ./ncurl get-config --format acton-adata --module ietf-netconf-acm --module ietf-yang-types
       - uses: actions/upload-artifact@v4
         with:
           name: ncurl-linux-x86_64

--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/40e4ac2d3772f82100ed80be3ede4570f9850813.zip",
-            "hash": "122083a088be74f823276c0a8975a81f82292178cc98c0ed71a37a4e88e550dc27c2"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/7a9a0eb87c1bc0d6a69a0f6ccddafd0b12ce80f5.zip",
+            "hash": "1220a7991b5c512d210b27cac0a2979b2c85463ba16580d5e48f7548371e36bb8e3f"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/f61aa55a25191d27cea10a5cf03ad7313d80692d.zip",
-            "hash": "122038c74d2acbbc75dff31bb053e5c57bfc2814d118de9e19e848edafac9417e85d"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/24aaa7bfce8f2064827915785e5f78ff2ce4560a.zip",
+            "hash": "12204a2a5bc10d5d9464ce3425f06ab0f8d67fa1b9323b8fcb291ae360fa8b77ef9b"
         }
     },
     "zig_dependencies": {}

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -90,6 +90,7 @@ actor CmdGetConfig(env, args, log_handler):
     output_file = args.get_str("output")
     format = args.get_str("format")
     module_sets = args.get_strlist("module-set")
+    explicit_modules = args.get_strlist("module")
 
     var config_xml: ?xml.Node = None
     var client: ?netconf.Client = None
@@ -98,6 +99,11 @@ actor CmdGetConfig(env, args, log_handler):
     def _on_connect(c: netconf.Client, e: ?Exception):
         if e is not None:
             print("Error: Failed to connect: {e}", err=True)
+            env.exit(1)
+
+        # Validate that module-set and module are mutually exclusive
+        if module_sets != [] and explicit_modules != []:
+            print("Error: Cannot specify both --module-set and --module options", err=True)
             env.exit(1)
 
         # Parse and validate module sets
@@ -189,8 +195,20 @@ actor CmdGetConfig(env, args, log_handler):
             if s.format != "yang":
                 continue
 
-            # Apply module set filtering if specified
-            if len(module_sets) > 0:
+            if len(explicit_modules) > 0:
+                # Use explicit module filtering
+                for module in explicit_modules:
+                    # Parse module specification (might include version as module@version)
+                    if "@" in module:
+                        module_parts = module.split("@", 1)
+                        if s.identifier == module_parts[0] and s.version == module_parts[1]:
+                            break
+                    elif s.identifier == module:
+                        break
+                else:
+                    continue
+            elif len(module_sets) > 0:
+                # Use module set filtering
                 if not schema_filter.should_include_module(s.identifier, module_sets):
                     continue
             else:
@@ -466,6 +484,7 @@ actor main(env):
         p_get_config.add_option("output", "str", "?", "", "Output file (if not specified, prints to stdout)")
         module_sets_help = "Module set(s) to include ({schema_filter.get_module_set_names()})"
         p_get_config.add_option("module-set", "strlist", "+", [], module_sets_help)
+        p_get_config.add_option("module", "strlist", "+", [], "Module(s) to include")
 
         p_get_schema = p.add_cmd("get-schema", "Download schema(s) from NETCONF server", cmd_get_schema)
         p_get_schema.add_arg("identifier", "Schema identifier or 'all' to download all schemas", True, "?")

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -154,8 +154,7 @@ actor CmdGetConfig(env, args, log_handler):
         # If format is not raw-xml, fetch schemas
         if format != "raw-xml":
             print("Fetching schemas for data conversion...")
-            schema_getter = netconf.SchemaGetter(c)
-            schema_getter.download(_on_schema_download, _on_schemas_complete, "all")
+            c.list_schemas(_on_list_schemas)
         else:
             # For raw-xml, just output the config
             if config_xml is not None:
@@ -170,17 +169,38 @@ actor CmdGetConfig(env, args, log_handler):
                     config = str(config_xml.text)
                 _output_config(config)
 
-    def _on_schema_download(current_index: int, total_schemas: int, schema: (identifier: str, namespace: ?str, version: ?str, format: str), schema_data: ?str, error: ?netconf.NetconfError):
+    def _on_list_schemas(c: netconf.Client, schemas: list[(identifier: str, namespace: str, version: str, format: str)], error: ?netconf.NetconfError):
+        if error is not None:
+            print("Error: Failed to list schemas: {error}", err=True)
+            env.exit(1)
+            return
+
+        # Filter only YANG schemas because we only compile YANG
+        # Skip models:
+        # - junos-rpc: all RPC modules use an undefined grouping?!
+        schemas_to_download = []
+        for s in schemas:
+            if s.format != "yang":
+                pass
+            elif s.identifier.startswith("junos-rpc"):
+                print("Skipping {s.identifier}: undefined grouping common-forwarding", err=True)
+            else:
+                schemas_to_download.append((identifier=s.identifier, version=s.version, format=s.format))
+
+        if len(schemas_to_download) == 0:
+            print("No schemas available for download", err=True)
+            env.exit(1)
+            return
+
+        print("Found {len(schemas_to_download)} schemas to download")
+        sg = netconf.SchemaGetter(c)
+        sg.download(_on_schema_download, _on_schemas_complete, schemas_to_download)
+
+    def _on_schema_download(current_index: int, total_schemas: int, schema: (identifier: str, version: ?str, format: ?str), schema_data: ?str, error: ?netconf.NetconfError):
         """Collect downloaded schemas into the list"""
         if error is not None:
             print("Error downloading {schema.identifier}: {error}", err=True)
         elif schema_data is not None:
-            # Skip models:
-            # - junos-rpc: all RPC modules use an undefined grouping?!
-            # - openconfig: on Cisco IOS XRd openconfig-mpls.yang doesn't compile because submodule overrides prefix of parent import
-            if schema.identifier.startswith("junos-rpc") or "openconfig" in schema.identifier:
-                print("Skipping {schema.identifier}", err=True)
-                return
             schemas.append(schema_data)
         else:
             print("Warning: no schema data received for {schema.identifier}", err=True)
@@ -289,14 +309,35 @@ actor CmdGetSchema(env, args, log_handler):
             print("Error: Failed to connect: {e}", err=True)
             env.exit(1)
         else:
-            schema_getter = netconf.SchemaGetter(c)
+            client = c  # Store client for later use
+            if identifier_str == "all":
+                # List all schemas first
+                c.list_schemas(_on_list_schemas)
+            else:
+                # Download single schema
+                schema_getter = netconf.SchemaGetter(c)
+                schemas_to_download = [(identifier=identifier_str, version=version, format=format)]
+                sg = schema_getter
+                if sg is not None:
+                    sg.download(_on_schema_download, _on_download_complete, schemas_to_download)
 
-            # Start download using SchemaGetter
-            sg = schema_getter
-            if sg is not None:
-                sg.download(_on_schema_download, _on_download_complete, identifier_str)
+    def _on_list_schemas(c: netconf.Client, schemas: list[(identifier: str, namespace: str, version: str, format: str)], error: ?netconf.NetconfError):
+        if error is not None:
+            print("Error: Failed to list schemas: {error}", err=True)
+            env.exit(1)
+            return
 
-    def _on_schema_download(current_index: int, total_schemas: int, schema: (identifier: ?str, namespace: ?str, version: ?str, format: ?str), schema_data: ?str, error: ?netconf.NetconfError):
+        # TODO: can the compiler "convert" the schemas argument list[(identifier: str, namespace: str, version: str, format: str)]
+        # to a list[(identifier: str, version: ?str, format: ?str)] where the namespace field is missing the other two are optional?
+        schemas_to_download = [(identifier=s.identifier, version=s.version, format=s.format) for s in schemas]
+
+        print("Found {len(schemas_to_download)} schemas to download")
+        schema_getter = netconf.SchemaGetter(c)
+        sg = schema_getter
+        if sg is not None:
+            sg.download(_on_schema_download, _on_download_complete, schemas_to_download)
+
+    def _on_schema_download(current_index: int, total_schemas: int, schema: (identifier: str, version: ?str, format: ?str), schema_data: ?str, error: ?netconf.NetconfError):
         """Handle each downloaded schema"""
         print("Downloading [{current_index}/{total_schemas}]: {schema.identifier}")
         if error is not None:
@@ -304,9 +345,9 @@ actor CmdGetSchema(env, args, log_handler):
         elif schema_data is not None:
             # Build proper filename with identifier and version
             filename = "{schema.identifier}"
-            if schema.version is not None:
+            if schema.version is not None and schema.version != "":
                 filename = "{schema.identifier}@{schema.version}"
-            if schema.format is not None:
+            if schema.format is not None and schema.format != "":
                 filename = "{filename}.{schema.format}"
             else:
                 filename = "{filename}.yang"

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -16,6 +16,7 @@ import xml
 
 import yang
 import yang.gen3
+import schema_filter
 
 
 
@@ -88,6 +89,7 @@ actor CmdGetConfig(env, args, log_handler):
     xpath_namespaces = args.get_strlist("xpath-namespaces")
     output_file = args.get_str("output")
     format = args.get_str("format")
+    module_sets = args.get_strlist("module-set")
 
     var config_xml: ?xml.Node = None
     var client: ?netconf.Client = None
@@ -97,6 +99,12 @@ actor CmdGetConfig(env, args, log_handler):
         if e is not None:
             print("Error: Failed to connect: {e}", err=True)
             env.exit(1)
+
+        # Parse and validate module sets
+        if module_sets != []:
+            warnings = schema_filter.validate_module_sets(module_sets)
+            for warning in warnings:
+                print(warning, err=True)
 
         # Build filter if provided
         filter_node: ?xml.Node = None
@@ -176,16 +184,24 @@ actor CmdGetConfig(env, args, log_handler):
             return
 
         # Filter only YANG schemas because we only compile YANG
-        # Skip models:
-        # - junos-rpc: all RPC modules use an undefined grouping?!
         schemas_to_download = []
         for s in schemas:
             if s.format != "yang":
-                pass
-            elif s.identifier.startswith("junos-rpc"):
-                print("Skipping {s.identifier}: undefined grouping common-forwarding", err=True)
+                continue
+
+            # Apply module set filtering if specified
+            if len(module_sets) > 0:
+                if not schema_filter.should_include_module(s.identifier, module_sets):
+                    continue
             else:
-                schemas_to_download.append((identifier=s.identifier, version=s.version, format=s.format))
+                # Use legacy filtering for backward compatibility
+                # Skip models:
+                # - junos-rpc: all RPC modules use an undefined grouping?!
+                if s.identifier.startswith("junos-rpc"):
+                    print("Skipping {s.identifier}: undefined grouping common-forwarding", err=True)
+                    continue
+
+            schemas_to_download.append((identifier=s.identifier, version=s.version, format=s.format))
 
         if len(schemas_to_download) == 0:
             print("No schemas available for download", err=True)
@@ -202,6 +218,7 @@ actor CmdGetConfig(env, args, log_handler):
             print("Error downloading {schema.identifier}: {error}", err=True)
         elif schema_data is not None:
             schemas.append(schema_data)
+            print("Downloaded [{current_index}/{total_schemas}]: {schema.identifier}")
         else:
             print("Warning: no schema data received for {schema.identifier}", err=True)
 
@@ -447,6 +464,8 @@ actor main(env):
         p_get_config.add_option("xpath-namespaces", "strlist", "*", [], "Namespace declarations for XPath filtering (format: prefix=uri)")
         p_get_config.add_option("format", "str", "?", "raw-xml", "Output format (raw-xml, xml, json, acton-gdata or acton-adata")
         p_get_config.add_option("output", "str", "?", "", "Output file (if not specified, prints to stdout)")
+        module_sets_help = "Module set(s) to include ({schema_filter.get_module_set_names()})"
+        p_get_config.add_option("module-set", "strlist", "+", [], module_sets_help)
 
         p_get_schema = p.add_cmd("get-schema", "Download schema(s) from NETCONF server", cmd_get_schema)
         p_get_schema.add_arg("identifier", "Schema identifier or 'all' to download all schemas", True, "?")

--- a/src/schema_filter.act
+++ b/src/schema_filter.act
@@ -1,0 +1,159 @@
+"""Schema filtering support for YANG module sets
+
+This module provides pattern-based filtering for YANG schemas, allowing
+users to select specific sets of modules (classic, unified-model, openconfig, etc.)
+to avoid conflicts and reduce compilation overhead.
+"""
+
+import re
+
+class ModuleSet:
+    """Represents a set of YANG modules defined by include/exclude patterns"""
+
+    name: str
+    description: str
+    include_patterns: list[str]
+    exclude_patterns: list[str]
+
+    def __init__(self, name: str, description: str, include_patterns: list[str]=[], exclude_patterns: list[str]=[]):
+        self.name = name
+        self.description = description
+        self.include_patterns = include_patterns
+        self.exclude_patterns = exclude_patterns
+
+    def matches(self, module_name: str) -> bool:
+        """Check if a module name matches this module set's patterns"""
+        # First check if it matches any include pattern
+        if len(self.include_patterns) == 0:
+            matched = True
+        else:
+            matched = False
+            for pattern in self.include_patterns:
+                if re.match(pattern, module_name) is not None:
+                    matched = True
+                    break
+
+        if not matched:
+            return False
+
+        # Then check it doesn't match any exclude pattern
+        for pattern in self.exclude_patterns:
+            if re.match(pattern, module_name) is not None:
+                return False
+
+        return True
+
+
+# Define standard module sets
+CISCO_XR_CLASSIC = ModuleSet(
+    "cisco-xr-classic",
+    "Cisco IOS XR Classic configuration models",
+    include_patterns=["^Cisco-IOS-XR-", "^tailf-", "^cisco-semver"],
+    exclude_patterns=["^Cisco-IOS-XR-um-"]
+)
+
+CISCO_XR_UNIFIED_MODEL = ModuleSet(
+    "cisco-xr-unified-model",
+    "Cisco IOS XR Unified Model with base types",
+    include_patterns=["^Cisco-IOS-XR-um-", "^Cisco-IOS-XR-types", "^Cisco-IOS-XR-.*-datatypes", "^ietf-", "^tailf-", "^cisco-semver"],
+    exclude_patterns=["^ietf-interfaces"]
+)
+
+OPENCONFIG = ModuleSet(
+    "openconfig",
+    "OpenConfig standard models",
+    include_patterns=["^openconfig-"]
+)
+
+IETF = ModuleSet(
+    "ietf",
+    "IETF standard models",
+    include_patterns=["^ietf-"]
+)
+
+STANDARDS_ONLY = ModuleSet(
+    "standards",
+    "Industry standard models only (IETF + OpenConfig)",
+    include_patterns=["^ietf-", "^openconfig-"]
+)
+
+ALL_MODULES = ModuleSet(
+    "all",
+    "All available models"
+)
+
+# Registry of all available module sets
+MODULE_SETS = {
+    "cisco-xr-classic": CISCO_XR_CLASSIC,
+    "cisco-xr-unified-model": CISCO_XR_UNIFIED_MODEL,
+    "openconfig": OPENCONFIG,
+    "ietf": IETF,
+    "standards": STANDARDS_ONLY,
+    "all": ALL_MODULES
+}
+
+
+def get_module_set(name: str) -> ?ModuleSet:
+    """Get a module set by name, returns None if not found"""
+    return MODULE_SETS.get(name)
+
+
+def should_include_module(module_name: str, module_set_names: list[str]) -> bool:
+    """Check if a module should be included based on selected module sets"""
+    # If no sets specified, include everything
+    if len(module_set_names) == 0:
+        return True
+
+    # Check if module matches any of the selected sets
+    for set_name in module_set_names:
+        module_set = get_module_set(set_name)
+        if module_set is not None and module_set.matches(module_name):
+            return True
+
+    return False
+
+
+def filter_schemas(
+    schemas: list[(identifier: str, namespace: ?str, version: ?str, format: str)],
+    module_set_names: list[str]
+) -> list[(identifier: str, namespace: ?str, version: ?str, format: str)]:
+    """Filter a list of schemas based on selected module sets"""
+    if len(module_set_names) == 0:
+        return schemas
+
+    filtered = []
+    for schema in schemas:
+        if should_include_module(schema.identifier, module_set_names):
+            filtered.append(schema)
+
+    return filtered
+
+
+def validate_module_sets(set_names: list[str]) -> list[str]:
+    """Validate module set names and check for known incompatibilities"""
+    warnings = []
+
+    # Check all set names are valid
+    for name in set_names:
+        if get_module_set(name) is None:
+            warnings.append("Unknown module set: {name}")
+
+    # Check for known incompatibilities
+    if "cisco-xr-classic" in set_names and "cisco-xr-unified-model" in set_names:
+        warnings.append("Warning: Cisco XR Classic and Cisco XR Unified Model may have conflicting definitions")
+
+    if "cisco-xr-classic" in set_names and "openconfig" in set_names:
+        warnings.append("Warning: Cisco XR Classic and OpenConfig may have overlapping namespaces for common features")
+
+    if "cisco-xr-unified-model" in set_names and "openconfig" in set_names:
+        warnings.append("Warning: Cisco XR Unified Model and OpenConfig may have overlapping namespaces")
+
+    return warnings
+
+
+def get_module_set_names() -> str:
+    """Get a comma-separated string of available module set names for help text"""
+    names = []
+    for key in MODULE_SETS:
+        names.append(key)
+    return ", ".join(sorted(names))


### PR DESCRIPTION
Adds pattern-based filtering to address conflicts between Cisco IOS XR model sets (Classic, Unified Model, OpenConfig). Sets use regex include/exclude patterns with union operation support. If a module is excluded by the set, then the YANG source is not downloaded.

Provides 7 predefined sets including classic, unified-model, openconfig, ietf, standards, cisco-native, and all. Right now this is only part of ncurl as a POC, but it will also be supported in netclics via an optional argument (and maybe orchestron?).

@klambrec WDYT?
